### PR TITLE
🎵 [feat] : Spotify 노래 검색/미리듣기/장르/차트 기능을 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ configurations {
 
 repositories {
 	mavenCentral()
+	maven { url 'https://jitpack.io' }
 }
 
 dependencies {
@@ -27,6 +28,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
+	implementation 'se.michaelthelin.spotify:spotify-web-api-java:8.0.0'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/example/Playlist_pack/Config/SpotifyConfig.java
+++ b/src/main/java/com/example/Playlist_pack/Config/SpotifyConfig.java
@@ -1,0 +1,50 @@
+package com.example.Playlist_pack.Config;
+
+import java.io.IOException;
+import java.time.Instant;
+import se.michaelthelin.spotify.SpotifyApi;
+import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
+import se.michaelthelin.spotify.model_objects.credentials.ClientCredentials;
+import se.michaelthelin.spotify.requests.authorization.client_credentials.ClientCredentialsRequest;
+
+public class SpotifyConfig {
+    private static final String CLIENT_ID = "9aa067b28e444056ab123c76058ca7ab";
+    private static final String CLIENT_SECRET = "28da9a874ab248ecae461398a4a20d53";
+    private static final SpotifyApi spotifyApi = new SpotifyApi.Builder().setClientId(CLIENT_ID).setClientSecret(CLIENT_SECRET).build();
+
+    private static String accessToken;
+    private static Instant accessTokenExpiration;
+
+//    public static String accessToken() {
+//        ClientCredentialsRequest clientCredentialsRequest = spotifyApi.clientCredentials().build();
+//        try {
+//            final ClientCredentials clientCredentials = clientCredentialsRequest.execute();
+//            spotifyApi.setAccessToken(clientCredentials.getAccessToken());
+//            return spotifyApi.getAccessToken();
+//        } catch (IOException | SpotifyWebApiException | org.apache.hc.core5.http.ParseException e) {
+//            System.out.println("Error: " + e.getMessage());
+//            return "error";
+//        }
+//    }
+
+    public static String getAccessToken(){
+        if (accessToken == null || Instant.now().isAfter(accessTokenExpiration)) {
+            refreshAccessToken();
+        }
+        return accessToken;
+    }
+
+    private static void refreshAccessToken() {
+        ClientCredentialsRequest clientCredentialsRequest = spotifyApi.clientCredentials().build();
+        try {
+            final ClientCredentials clientCredentials = clientCredentialsRequest.execute();
+            accessToken = clientCredentials.getAccessToken();
+            // 토큰의 유효 시간을 계산하여 저장합니다.
+            accessTokenExpiration = Instant.now().plusSeconds(clientCredentials.getExpiresIn());
+            spotifyApi.setAccessToken(accessToken);
+        } catch (IOException | SpotifyWebApiException | org.apache.hc.core5.http.ParseException e) {
+            System.out.println("Error: " + e.getMessage());
+            accessToken = "error";
+        }
+    }
+}

--- a/src/main/java/com/example/Playlist_pack/Controller/SpotifyController.java
+++ b/src/main/java/com/example/Playlist_pack/Controller/SpotifyController.java
@@ -1,0 +1,35 @@
+package com.example.Playlist_pack.Controller;
+
+import com.example.Playlist_pack.Dto.SpotifySearchResponseDto;
+import com.example.Playlist_pack.Service.SpotifyService;
+import java.io.IOException;
+import java.text.ParseException;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
+
+@CrossOrigin(origins = "*")
+@RestController
+public class SpotifyController {
+    @Autowired
+    SpotifyService spotifyService =new SpotifyService();
+
+    @GetMapping("/search/{trackname}")
+    public List<SpotifySearchResponseDto>searchTracksByTrackname(@PathVariable String trackname) throws IOException, ParseException, SpotifyWebApiException {
+
+
+        return spotifyService.SearchByTrackname(trackname);
+    }
+
+    @GetMapping("/search/{artist}/{trackname}")
+    public List<SpotifySearchResponseDto> searchTracksByTracknameAndArtist(@PathVariable String trackname,@PathVariable String artist) throws IOException, ParseException, SpotifyWebApiException {
+
+
+        return spotifyService.SearchByTracknameAndArtist(trackname,artist);
+    }
+
+}

--- a/src/main/java/com/example/Playlist_pack/Controller/SpotifyController.java
+++ b/src/main/java/com/example/Playlist_pack/Controller/SpotifyController.java
@@ -38,4 +38,11 @@ public class SpotifyController {
             throws IOException, SpotifyWebApiException {
         return spotifyService.searchByGenre(genre);
     }
+    @GetMapping("/TodayHot100")
+    public List<SpotifySearchResponseDto> getHot100Chart()
+            throws IOException, SpotifyWebApiException {
+        return spotifyService.getHot100Chart();
+    }
+
+
 }

--- a/src/main/java/com/example/Playlist_pack/Controller/SpotifyController.java
+++ b/src/main/java/com/example/Playlist_pack/Controller/SpotifyController.java
@@ -44,5 +44,11 @@ public class SpotifyController {
         return spotifyService.getHot100Chart();
     }
 
+    @GetMapping("/KoreanHot100")
+    public List<SpotifySearchResponseDto> getKoreanHot100chart()
+            throws IOException, SpotifyWebApiException {
+        return spotifyService.getKoreanHot100Chart();
+    }
+
 
 }

--- a/src/main/java/com/example/Playlist_pack/Controller/SpotifyController.java
+++ b/src/main/java/com/example/Playlist_pack/Controller/SpotifyController.java
@@ -32,4 +32,10 @@ public class SpotifyController {
         return spotifyService.SearchByTracknameAndArtist(trackname,artist);
     }
 
+
+    @GetMapping("/search/genre/{genre}")
+    public List<SpotifySearchResponseDto> searchTracksByGenre(@PathVariable String genre)
+            throws IOException, SpotifyWebApiException {
+        return spotifyService.searchByGenre(genre);
+    }
 }

--- a/src/main/java/com/example/Playlist_pack/Domain/User.java
+++ b/src/main/java/com/example/Playlist_pack/Domain/User.java
@@ -16,7 +16,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import org.springframework.security.crypto.password.PasswordEncoder;
+
 
 
 @Getter

--- a/src/main/java/com/example/Playlist_pack/Dto/SpotifyDtoMapper.java
+++ b/src/main/java/com/example/Playlist_pack/Dto/SpotifyDtoMapper.java
@@ -1,0 +1,12 @@
+package com.example.Playlist_pack.Dto;
+
+public class SpotifyDtoMapper {
+    public static SpotifySearchResponseDto toSearchDto(String artistName, String title, String albumName, String imageUrl) {
+        return  SpotifySearchResponseDto.builder()
+                .artistName(artistName)
+                .title(title)
+                .albumName(albumName)
+                .imageUrl(imageUrl)
+                .build();
+    }
+}

--- a/src/main/java/com/example/Playlist_pack/Dto/SpotifyDtoMapper.java
+++ b/src/main/java/com/example/Playlist_pack/Dto/SpotifyDtoMapper.java
@@ -1,12 +1,13 @@
 package com.example.Playlist_pack.Dto;
 
 public class SpotifyDtoMapper {
-    public static SpotifySearchResponseDto toSearchDto(String artistName, String title, String albumName, String imageUrl) {
+    public static SpotifySearchResponseDto toSearchDto(String artistName, String title, String albumName, String imageUrl, String previewUrl) {
         return  SpotifySearchResponseDto.builder()
                 .artistName(artistName)
                 .title(title)
                 .albumName(albumName)
                 .imageUrl(imageUrl)
+                .previewUrl(previewUrl)
                 .build();
     }
 }

--- a/src/main/java/com/example/Playlist_pack/Dto/SpotifySearchResponseDto.java
+++ b/src/main/java/com/example/Playlist_pack/Dto/SpotifySearchResponseDto.java
@@ -1,0 +1,8 @@
+package com.example.Playlist_pack.Dto;
+
+public class SpotifySearchResponseDto {
+    private String artistName;
+    private String title;
+    private String albumName;
+    private String imageUrl;
+}

--- a/src/main/java/com/example/Playlist_pack/Dto/SpotifySearchResponseDto.java
+++ b/src/main/java/com/example/Playlist_pack/Dto/SpotifySearchResponseDto.java
@@ -10,4 +10,5 @@ public class SpotifySearchResponseDto {
     private String title;
     private String albumName;
     private String imageUrl;
+    private String previewUrl;
 }

--- a/src/main/java/com/example/Playlist_pack/Dto/SpotifySearchResponseDto.java
+++ b/src/main/java/com/example/Playlist_pack/Dto/SpotifySearchResponseDto.java
@@ -1,5 +1,10 @@
 package com.example.Playlist_pack.Dto;
 
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
 public class SpotifySearchResponseDto {
     private String artistName;
     private String title;

--- a/src/main/java/com/example/Playlist_pack/Service/SpotifyService.java
+++ b/src/main/java/com/example/Playlist_pack/Service/SpotifyService.java
@@ -5,6 +5,7 @@ import com.example.Playlist_pack.Dto.SpotifyDtoMapper;
 import com.example.Playlist_pack.Dto.SpotifySearchResponseDto;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import org.springframework.stereotype.Service;
 import se.michaelthelin.spotify.SpotifyApi;
@@ -135,6 +136,43 @@ public class SpotifyService {
         } catch (IOException | SpotifyWebApiException | org.apache.hc.core5.http.ParseException e) {
             System.out.println("Error: " + e.getMessage());
         }
+        return searchResponseDtoList;
+    }
+    public List<SpotifySearchResponseDto> getHot100Chart() {
+        SpotifyApi spotifyApi = new SpotifyApi.Builder()
+                .setAccessToken(SpotifyConfig.getAccessToken())
+                .build();
+
+        List<SpotifySearchResponseDto> searchResponseDtoList = new ArrayList<>();
+
+        try {
+            GetPlaylistRequest getHot100PlaylistRequest = spotifyApi.getPlaylist("37i9dQZEVXbMDoHDwVN2tF") // HOT 100 playlist ID
+                    .build();
+
+            Playlist hot100Playlist = getHot100PlaylistRequest.execute();
+            List<PlaylistTrack> tracks = Arrays.asList(hot100Playlist.getTracks().getItems());
+
+            for (PlaylistTrack playlistTrack : tracks) {
+                Track track = (Track) playlistTrack.getTrack();
+                String title = track.getName();
+                String previewUrl = track.getPreviewUrl();
+
+                AlbumSimplified album = track.getAlbum();
+                ArtistSimplified[] artists = album.getArtists();
+                String artistName = artists[0].getName();
+
+                Image[] images = album.getImages();
+                String imageUrl = (images.length > 0) ? images[0].getUrl() : "NO_IMAGE";
+
+                String albumName = album.getName();
+
+                searchResponseDtoList.add(SpotifyDtoMapper.toSearchDto(artistName, title, albumName, imageUrl, previewUrl));
+            }
+
+        } catch (IOException | SpotifyWebApiException | org.apache.hc.core5.http.ParseException e) {
+            System.out.println("Error: " + e.getMessage());
+        }
+
         return searchResponseDtoList;
     }
 

--- a/src/main/java/com/example/Playlist_pack/Service/SpotifyService.java
+++ b/src/main/java/com/example/Playlist_pack/Service/SpotifyService.java
@@ -1,4 +1,93 @@
 package com.example.Playlist_pack.Service;
 
+import com.example.Playlist_pack.Config.SpotifyConfig;
+import com.example.Playlist_pack.Dto.SpotifyDtoMapper;
+import com.example.Playlist_pack.Dto.SpotifySearchResponseDto;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.stereotype.Service;
+import se.michaelthelin.spotify.SpotifyApi;
+import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
+import se.michaelthelin.spotify.model_objects.specification.AlbumSimplified;
+import se.michaelthelin.spotify.model_objects.specification.ArtistSimplified;
+import se.michaelthelin.spotify.model_objects.specification.Image;
+import se.michaelthelin.spotify.model_objects.specification.Paging;
+import se.michaelthelin.spotify.model_objects.specification.Track;
+import se.michaelthelin.spotify.requests.data.search.simplified.SearchTracksRequest;
+
+@Service
 public class SpotifyService {
+    public List<SpotifySearchResponseDto> SearchByTrackname(String trackname) {
+        SpotifyApi spotifyApi = new SpotifyApi.Builder()
+                .setAccessToken(SpotifyConfig.getAccessToken())
+                .build();
+
+        List<SpotifySearchResponseDto> searchResponseDtoList = new ArrayList<>();
+
+        try {
+            SearchTracksRequest searchTrackRequest = spotifyApi.searchTracks(trackname)
+                    .limit(50)
+                    .build();
+
+            Paging<Track> searchResult = searchTrackRequest.execute();
+            Track[] tracks = searchResult.getItems();
+
+            for (Track track : tracks) {
+                String title = track.getName();
+
+                AlbumSimplified album = track.getAlbum();
+                ArtistSimplified[] artists = album.getArtists();
+                String artistName = artists[0].getName();
+
+                Image[] images = album.getImages();
+                String imageUrl = (images.length > 0) ? images[0].getUrl() : "NO_IMAGE";
+
+                String albumName = album.getName();
+
+                searchResponseDtoList.add(SpotifyDtoMapper.toSearchDto(artistName, title, albumName, imageUrl));
+            }
+
+        } catch (IOException | SpotifyWebApiException | org.apache.hc.core5.http.ParseException e) {
+            System.out.println("Error: " + e.getMessage());
+        }
+        return searchResponseDtoList;
+    }
+
+
+    public List<SpotifySearchResponseDto> SearchByTracknameAndArtist(String trackname, String Artist) {
+        SpotifyApi spotifyApi = new SpotifyApi.Builder()
+                .setAccessToken(SpotifyConfig.getAccessToken())
+                .build();
+
+        List<SpotifySearchResponseDto> searchResponseDtoList = new ArrayList<>();
+
+        try {
+            SearchTracksRequest searchTrackRequest = spotifyApi.searchTracks("track:" + trackname + " artist:" + Artist)
+                    .limit(1)
+                    .build();
+
+            Paging<Track> searchResult = searchTrackRequest.execute();
+            Track[] tracks = searchResult.getItems();
+
+            for (Track track : tracks) {
+                String title = track.getName();
+
+                AlbumSimplified album = track.getAlbum();
+                ArtistSimplified[] artists = album.getArtists();
+                String artistName = artists[0].getName();
+
+                Image[] images = album.getImages();
+                String imageUrl = (images.length > 0) ? images[0].getUrl() : "NO_IMAGE";
+
+                String albumName = album.getName();
+
+                searchResponseDtoList.add(SpotifyDtoMapper.toSearchDto(artistName, title, albumName, imageUrl));
+            }
+
+        } catch (IOException | SpotifyWebApiException | org.apache.hc.core5.http.ParseException e) {
+            System.out.println("Error: " + e.getMessage());
+        }
+        return searchResponseDtoList;
+    }
 }

--- a/src/main/java/com/example/Playlist_pack/Service/SpotifyService.java
+++ b/src/main/java/com/example/Playlist_pack/Service/SpotifyService.java
@@ -101,4 +101,41 @@ public class SpotifyService {
         return searchResponseDtoList;
     }
 
+    public List<SpotifySearchResponseDto> searchByGenre(String genre) {
+        SpotifyApi spotifyApi = new SpotifyApi.Builder()
+                .setAccessToken(SpotifyConfig.getAccessToken())
+                .build();
+
+        List<SpotifySearchResponseDto> searchResponseDtoList = new ArrayList<>();
+
+        try {
+            SearchTracksRequest searchTracksRequest = spotifyApi.searchTracks("genre:" + genre)
+                    .limit(50)
+                    .build();
+
+            Paging<Track> searchResult = searchTracksRequest.execute();
+            Track[] tracks = searchResult.getItems();
+
+            for (Track track : tracks) {
+                String title = track.getName();
+                String previewUrl = track.getPreviewUrl();
+
+                AlbumSimplified album = track.getAlbum();
+                ArtistSimplified[] artists = album.getArtists();
+                String artistName = artists[0].getName();
+
+                Image[] images = album.getImages();
+                String imageUrl = (images.length > 0) ? images[0].getUrl() : "NO_IMAGE";
+
+                String albumName = album.getName();
+
+                searchResponseDtoList.add(SpotifyDtoMapper.toSearchDto(artistName, title, albumName, imageUrl, previewUrl));
+            }
+
+        } catch (IOException | SpotifyWebApiException | org.apache.hc.core5.http.ParseException e) {
+            System.out.println("Error: " + e.getMessage());
+        }
+        return searchResponseDtoList;
+    }
+
 }

--- a/src/main/java/com/example/Playlist_pack/Service/SpotifyService.java
+++ b/src/main/java/com/example/Playlist_pack/Service/SpotifyService.java
@@ -146,7 +146,44 @@ public class SpotifyService {
         List<SpotifySearchResponseDto> searchResponseDtoList = new ArrayList<>();
 
         try {
-            GetPlaylistRequest getHot100PlaylistRequest = spotifyApi.getPlaylist("37i9dQZEVXbMDoHDwVN2tF") // HOT 100 playlist ID
+            GetPlaylistRequest getHot100PlaylistRequest = spotifyApi.getPlaylist("37i9dQZF1DXcBWIGoYBM5M") // HOT 100 playlist ID
+                    .build();
+
+            Playlist hot100Playlist = getHot100PlaylistRequest.execute();
+            List<PlaylistTrack> tracks = Arrays.asList(hot100Playlist.getTracks().getItems());
+
+            for (PlaylistTrack playlistTrack : tracks) {
+                Track track = (Track) playlistTrack.getTrack();
+                String title = track.getName();
+                String previewUrl = track.getPreviewUrl();
+
+                AlbumSimplified album = track.getAlbum();
+                ArtistSimplified[] artists = album.getArtists();
+                String artistName = artists[0].getName();
+
+                Image[] images = album.getImages();
+                String imageUrl = (images.length > 0) ? images[0].getUrl() : "NO_IMAGE";
+
+                String albumName = album.getName();
+
+                searchResponseDtoList.add(SpotifyDtoMapper.toSearchDto(artistName, title, albumName, imageUrl, previewUrl));
+            }
+
+        } catch (IOException | SpotifyWebApiException | org.apache.hc.core5.http.ParseException e) {
+            System.out.println("Error: " + e.getMessage());
+        }
+
+        return searchResponseDtoList;
+    }
+    public List<SpotifySearchResponseDto> getKoreanHot100Chart() {
+        SpotifyApi spotifyApi = new SpotifyApi.Builder()
+                .setAccessToken(SpotifyConfig.getAccessToken())
+                .build();
+
+        List<SpotifySearchResponseDto> searchResponseDtoList = new ArrayList<>();
+
+        try {
+            GetPlaylistRequest getHot100PlaylistRequest = spotifyApi.getPlaylist("37i9dQZEVXbJZGli0rRP3r") // HOT 100 playlist ID
                     .build();
 
             Playlist hot100Playlist = getHot100PlaylistRequest.execute();

--- a/src/main/java/com/example/Playlist_pack/Service/SpotifyService.java
+++ b/src/main/java/com/example/Playlist_pack/Service/SpotifyService.java
@@ -1,0 +1,4 @@
+package com.example.Playlist_pack.Service;
+
+public class SpotifyService {
+}

--- a/src/main/java/com/example/Playlist_pack/Service/SpotifyService.java
+++ b/src/main/java/com/example/Playlist_pack/Service/SpotifyService.java
@@ -10,11 +10,17 @@ import org.springframework.stereotype.Service;
 import se.michaelthelin.spotify.SpotifyApi;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
 import se.michaelthelin.spotify.model_objects.specification.AlbumSimplified;
+import se.michaelthelin.spotify.model_objects.specification.Artist;
 import se.michaelthelin.spotify.model_objects.specification.ArtistSimplified;
 import se.michaelthelin.spotify.model_objects.specification.Image;
 import se.michaelthelin.spotify.model_objects.specification.Paging;
+import se.michaelthelin.spotify.model_objects.specification.Playlist;
+import se.michaelthelin.spotify.model_objects.specification.PlaylistTrack;
 import se.michaelthelin.spotify.model_objects.specification.Track;
+import se.michaelthelin.spotify.requests.data.playlists.GetPlaylistRequest;
+import se.michaelthelin.spotify.requests.data.search.simplified.SearchArtistsRequest;
 import se.michaelthelin.spotify.requests.data.search.simplified.SearchTracksRequest;
+import se.michaelthelin.spotify.requests.data.tracks.GetTrackRequest;
 
 @Service
 public class SpotifyService {
@@ -35,6 +41,8 @@ public class SpotifyService {
 
             for (Track track : tracks) {
                 String title = track.getName();
+                String previewUrl=track.getPreviewUrl();
+
 
                 AlbumSimplified album = track.getAlbum();
                 ArtistSimplified[] artists = album.getArtists();
@@ -45,7 +53,8 @@ public class SpotifyService {
 
                 String albumName = album.getName();
 
-                searchResponseDtoList.add(SpotifyDtoMapper.toSearchDto(artistName, title, albumName, imageUrl));
+
+                searchResponseDtoList.add(SpotifyDtoMapper.toSearchDto(artistName, title, albumName, imageUrl,previewUrl));
             }
 
         } catch (IOException | SpotifyWebApiException | org.apache.hc.core5.http.ParseException e) {
@@ -72,6 +81,7 @@ public class SpotifyService {
 
             for (Track track : tracks) {
                 String title = track.getName();
+                String previewUrl=track.getPreviewUrl();
 
                 AlbumSimplified album = track.getAlbum();
                 ArtistSimplified[] artists = album.getArtists();
@@ -82,7 +92,7 @@ public class SpotifyService {
 
                 String albumName = album.getName();
 
-                searchResponseDtoList.add(SpotifyDtoMapper.toSearchDto(artistName, title, albumName, imageUrl));
+                searchResponseDtoList.add(SpotifyDtoMapper.toSearchDto(artistName, title, albumName, imageUrl,previewUrl));
             }
 
         } catch (IOException | SpotifyWebApiException | org.apache.hc.core5.http.ParseException e) {
@@ -90,4 +100,5 @@ public class SpotifyService {
         }
         return searchResponseDtoList;
     }
+
 }

--- a/src/main/web/WEB-INF/web.xml
+++ b/src/main/web/WEB-INF/web.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_4_0.xsd"
+         version="4.0">
+</web-app>


### PR DESCRIPTION
1.현재 실시간 인기차트 50 데이터를 반환하는 기능 구현
2.현재 대한민국 인기차트 50 데이터를 반환하는 기능 구현.
3.음악을 검색하고 해당 검색 반환 JSON 키 값에 MP3 URL이 포함되도록 미리듣기 기능구현
4.장르를 검색하면 해당 장르에 속하는 노래가 검색되는 기능을 구현
