### PR TITLE
✔️ [Fix] :  requestDTO의 @Notnull 기능 정상동작하도록 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/src/main/java/com/hositamtam/plypockets/controller/PlaylistController.java
+++ b/src/main/java/com/hositamtam/plypockets/controller/PlaylistController.java
@@ -10,6 +10,7 @@ import com.hositamtam.plypockets.service.PlaylistService;
 import com.hositamtam.plypockets.service.SpotifyService;
 import com.mysql.cj.util.StringUtils;
 import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.bind.annotation.*;
@@ -31,7 +32,7 @@ public class PlaylistController {
 
     @PostMapping("/{nickname}")
     @Operation(summary = "선물 등록", description = "사용자가 선물을 전송합니다.")
-    public HttpResponse createPlaylist(@RequestBody PlaylistRegisterRequestDto playlistRegisterRequestDto, @PathVariable String nickname) {
+    public HttpResponse createPlaylist(@Valid @RequestBody PlaylistRegisterRequestDto playlistRegisterRequestDto, @PathVariable String nickname) {
         playlistService.createPlaylist(playlistRegisterRequestDto, nickname);
         return HttpResponse.createdBuilder().build();
     }

--- a/src/main/java/com/hositamtam/plypockets/global/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/hositamtam/plypockets/global/exception/handler/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import com.hositamtam.plypockets.global.dto.response.ErrorResponseDto;
 import com.hositamtam.plypockets.global.dto.response.HttpResponse;
 import com.hositamtam.plypockets.global.exception.HttpExceptionCode;
 import com.hositamtam.plypockets.global.exception.custom.BusinessException;
+import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
@@ -40,17 +41,12 @@ public class GlobalExceptionHandler {
 
         BindingResult bindingResult = e.getBindingResult();
 
-        StringBuilder builder = new StringBuilder();
-        for (FieldError fieldError : bindingResult.getFieldErrors()) {
-            builder.append("[");
-            builder.append(fieldError.getField());
-            builder.append("](은)는 ");
-            builder.append(fieldError.getDefaultMessage());
-            builder.append(" -> 입력된 값: ");
-            builder.append(fieldError.getRejectedValue());
-            builder.append(" & ");
-        }
+        String errorMessage = bindingResult.getFieldErrors()
+                .stream()
+                .map(FieldError::getDefaultMessage)
+                .collect(Collectors.joining());
+
         return ResponseEntity.badRequest()
-                .body(ErrorResponseDto.from(HttpExceptionCode.INVALID_ARGUMENT.getHttpStatus(), builder.toString()));
+                .body(ErrorResponseDto.from(HttpExceptionCode.INVALID_ARGUMENT.getHttpStatus(), errorMessage.toString()));
     }
 }

--- a/src/main/java/com/hositamtam/plypockets/global/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/hositamtam/plypockets/global/exception/handler/GlobalExceptionHandler.java
@@ -47,6 +47,6 @@ public class GlobalExceptionHandler {
                 .collect(Collectors.joining());
 
         return ResponseEntity.badRequest()
-                .body(ErrorResponseDto.from(HttpExceptionCode.INVALID_ARGUMENT.getHttpStatus(), errorMessage.toString()));
+                .body(ErrorResponseDto.from(HttpExceptionCode.INVALID_ARGUMENT.getHttpStatus(), errorMessage));
     }
 }


### PR DESCRIPTION
기존에 동작하지 않았던 javax.validation.constraints의 @NotNull 어노테이션 기능을 새로운 의존성을 추가하여 동작하게 하였습니다. 
해당 DTO에 @Notnull이 붙은 필드에 JSON value가 Null이면, 자바라이브러리 얘외인 MethodArgumentNotValidException.class가 호출되고, 해당 익셉션은 커스텀 익셉션이 아니므로, GlobalExceptionHandler에서 처리하도록 하였습니다.