### PR TITLE
♻️ [refactor] : spotify API 성능 개선

### DIFF
--- a/src/main/java/com/hositamtam/plypockets/config/SpotifyConfig.java
+++ b/src/main/java/com/hositamtam/plypockets/config/SpotifyConfig.java
@@ -2,30 +2,39 @@ package com.hositamtam.plypockets.config;
 
 import java.io.IOException;
 import java.time.Instant;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.apache.bcel.generic.RET;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
 import se.michaelthelin.spotify.SpotifyApi;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
 import se.michaelthelin.spotify.model_objects.credentials.ClientCredentials;
 import se.michaelthelin.spotify.requests.authorization.client_credentials.ClientCredentialsRequest;
 
+@Slf4j
+@Component
 public class SpotifyConfig {
-    private static final String CLIENT_ID = "9aa067b28e444056ab123c76058ca7ab";
-    private static final String CLIENT_SECRET = "28da9a874ab248ecae461398a4a20d53";
+
+    private static String CLIENT_ID ="9aa067b28e444056ab123c76058ca7ab";
+
+    private static String CLIENT_SECRET ="28da9a874ab248ecae461398a4a20d53";
+
+
+//    @Value("${spotify.registration.client-id}")
+//    public void setClientId(String clientId) {
+//        CLIENT_ID=clientId;
+//    }
+//
+//    @Value("${spotify.registration.client-secret}")
+//    public void setClientSecret(String clientSecret) {
+//        CLIENT_SECRET=clientSecret;
+//    }
     private static final SpotifyApi spotifyApi = new SpotifyApi.Builder().setClientId(CLIENT_ID).setClientSecret(CLIENT_SECRET).build();
 
     private static String accessToken;
     private static Instant accessTokenExpiration;
-
-//    public static String accessToken() {
-//        ClientCredentialsRequest clientCredentialsRequest = spotifyApi.clientCredentials().build();
-//        try {
-//            final ClientCredentials clientCredentials = clientCredentialsRequest.execute();
-//            spotifyApi.setAccessToken(clientCredentials.getAccessToken());
-//            return spotifyApi.getAccessToken();
-//        } catch (IOException | SpotifyWebApiException | org.apache.hc.core5.http.ParseException e) {
-//            System.out.println("Error: " + e.getMessage());
-//            return "error";
-//        }
-//    }
 
     public static String getAccessToken(){
         if (accessToken == null || Instant.now().isAfter(accessTokenExpiration)) {
@@ -36,12 +45,24 @@ public class SpotifyConfig {
 
     private static void refreshAccessToken() {
         ClientCredentialsRequest clientCredentialsRequest = spotifyApi.clientCredentials().build();
+        log.info("새로운 리프레쉬 토큰 발급을 위한 과정 시작");
+        log.info("현재 정의된 Client-id : "+CLIENT_ID);
+        log.info("현재 정의된 Client-secret : "+CLIENT_SECRET);
+
         try {
+
             final ClientCredentials clientCredentials = clientCredentialsRequest.execute();
+
+            log.info("0");
             accessToken = clientCredentials.getAccessToken();
+            log.info("현재 발급된 토큰 : "+accessToken);
             // 토큰의 유효 시간을 계산하여 저장합니다.
             accessTokenExpiration = Instant.now().plusSeconds(clientCredentials.getExpiresIn());
+            log.info("2");
+
             spotifyApi.setAccessToken(accessToken);
+            log.info("3");
+
         } catch (IOException | SpotifyWebApiException | org.apache.hc.core5.http.ParseException e) {
             System.out.println("Error: " + e.getMessage());
             accessToken = "error";

--- a/src/main/java/com/hositamtam/plypockets/config/SpotifyConfig.java
+++ b/src/main/java/com/hositamtam/plypockets/config/SpotifyConfig.java
@@ -22,15 +22,6 @@ public class SpotifyConfig {
     private static String CLIENT_SECRET ="28da9a874ab248ecae461398a4a20d53";
 
 
-//    @Value("${spotify.registration.client-id}")
-//    public void setClientId(String clientId) {
-//        CLIENT_ID=clientId;
-//    }
-//
-//    @Value("${spotify.registration.client-secret}")
-//    public void setClientSecret(String clientSecret) {
-//        CLIENT_SECRET=clientSecret;
-//    }
     private static final SpotifyApi spotifyApi = new SpotifyApi.Builder().setClientId(CLIENT_ID).setClientSecret(CLIENT_SECRET).build();
 
     private static String accessToken;
@@ -45,23 +36,15 @@ public class SpotifyConfig {
 
     private static void refreshAccessToken() {
         ClientCredentialsRequest clientCredentialsRequest = spotifyApi.clientCredentials().build();
-        log.info("새로운 리프레쉬 토큰 발급을 위한 과정 시작");
-        log.info("현재 정의된 Client-id : "+CLIENT_ID);
-        log.info("현재 정의된 Client-secret : "+CLIENT_SECRET);
-
         try {
 
             final ClientCredentials clientCredentials = clientCredentialsRequest.execute();
 
-            log.info("0");
             accessToken = clientCredentials.getAccessToken();
-            log.info("현재 발급된 토큰 : "+accessToken);
             // 토큰의 유효 시간을 계산하여 저장합니다.
             accessTokenExpiration = Instant.now().plusSeconds(clientCredentials.getExpiresIn());
-            log.info("2");
 
             spotifyApi.setAccessToken(accessToken);
-            log.info("3");
 
         } catch (IOException | SpotifyWebApiException | org.apache.hc.core5.http.ParseException e) {
             System.out.println("Error: " + e.getMessage());

--- a/src/main/java/com/hositamtam/plypockets/controller/SpotifyController.java
+++ b/src/main/java/com/hositamtam/plypockets/controller/SpotifyController.java
@@ -2,6 +2,7 @@ package com.hositamtam.plypockets.controller;
 
 import com.hositamtam.plypockets.dto.SpotifySearchResponseDto;
 import com.hositamtam.plypockets.service.SpotifyService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -15,9 +16,9 @@ import java.util.List;
 
 @CrossOrigin(origins = "*")
 @RestController
+@RequiredArgsConstructor
 public class SpotifyController {
-    @Autowired
-    SpotifyService spotifyService =new SpotifyService();
+    private final SpotifyService spotifyService;
 
     @GetMapping("/search/{trackname}")
     public List<SpotifySearchResponseDto> searchTracksByTrackname(@PathVariable String trackname) throws IOException, ParseException, SpotifyWebApiException {

--- a/src/main/java/com/hositamtam/plypockets/service/SpotifyService.java
+++ b/src/main/java/com/hositamtam/plypockets/service/SpotifyService.java
@@ -4,6 +4,7 @@ import com.hositamtam.plypockets.config.SpotifyConfig;
 import com.hositamtam.plypockets.dto.SpotifyDtoMapper;
 import com.hositamtam.plypockets.dto.SpotifySearchResponseDto;
 import com.hositamtam.plypockets.global.exception.custom.spotify.SpotifyErrorException;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.hc.core5.http.ParseException;
 import org.springframework.cache.annotation.Cacheable;
@@ -24,10 +25,14 @@ import java.util.List;
 @Service
 @Transactional
 @Slf4j
+@RequiredArgsConstructor
 public class SpotifyService {
+
+    private final SpotifyConfig spotifyConfig;
+
     public List<SpotifySearchResponseDto> SearchByTrackname(String trackname) {
         SpotifyApi spotifyApi = new SpotifyApi.Builder()
-                .setAccessToken(SpotifyConfig.getAccessToken())
+                .setAccessToken(spotifyConfig.getAccessToken())
                 .build();
 
         List<SpotifySearchResponseDto> searchResponseDtoList = new ArrayList<>();
@@ -69,7 +74,7 @@ public class SpotifyService {
 
     public List<SpotifySearchResponseDto> SearchByTracknameAndArtist(String trackname, String Artist) {
         SpotifyApi spotifyApi = new SpotifyApi.Builder()
-                .setAccessToken(SpotifyConfig.getAccessToken())
+                .setAccessToken(spotifyConfig.getAccessToken())
                 .build();
 
         List<SpotifySearchResponseDto> searchResponseDtoList = new ArrayList<>();
@@ -107,7 +112,7 @@ public class SpotifyService {
 
     public List<SpotifySearchResponseDto> searchByGenre(String genre) {
         SpotifyApi spotifyApi = new SpotifyApi.Builder()
-                .setAccessToken(SpotifyConfig.getAccessToken())
+                .setAccessToken(spotifyConfig.getAccessToken())
                 .build();
 
         List<SpotifySearchResponseDto> searchResponseDtoList = new ArrayList<>();
@@ -146,7 +151,7 @@ public class SpotifyService {
     @Cacheable(cacheNames = "hot100Cache", key = "'hot100'")
     public List<SpotifySearchResponseDto> getHot100Chart() {
         SpotifyApi spotifyApi = new SpotifyApi.Builder()
-                .setAccessToken(SpotifyConfig.getAccessToken())
+                .setAccessToken(spotifyConfig.getAccessToken())
                 .build();
 
         List<SpotifySearchResponseDto> searchResponseDtoList = new ArrayList<>();
@@ -186,7 +191,7 @@ public class SpotifyService {
     @Cacheable(cacheNames = "koreaHot100Cache", key = "'koreaHot100'")
     public List<SpotifySearchResponseDto> getKoreanHot100Chart() {
         SpotifyApi spotifyApi = new SpotifyApi.Builder()
-                .setAccessToken(SpotifyConfig.getAccessToken())
+                .setAccessToken(spotifyConfig.getAccessToken())
                 .build();
 
         List<SpotifySearchResponseDto> searchResponseDtoList = new ArrayList<>();
@@ -225,7 +230,7 @@ public class SpotifyService {
 
     public SpotifySearchResponseDto getTrackBySpotifyId(String spotifyId)  {
         SpotifyApi spotifyApi = new SpotifyApi.Builder()
-                .setAccessToken(SpotifyConfig.getAccessToken())
+                .setAccessToken(spotifyConfig.getAccessToken())
                 .build();
 
         try {

--- a/src/main/java/com/hositamtam/plypockets/service/SpotifyService.java
+++ b/src/main/java/com/hositamtam/plypockets/service/SpotifyService.java
@@ -26,7 +26,6 @@ import java.util.List;
 @Service
 @Transactional
 @Slf4j
-
 public class SpotifyService {
 
     @Autowired

--- a/src/main/java/com/hositamtam/plypockets/service/SpotifyService.java
+++ b/src/main/java/com/hositamtam/plypockets/service/SpotifyService.java
@@ -28,11 +28,17 @@ import java.util.List;
 @Slf4j
 public class SpotifyService {
 
+    private final SpotifyConfig spotifyConfig;
+    private final SpotifyApi spotifyApi;
+
     @Autowired
-    private SpotifyConfig spotifyConfig;
-    private SpotifyApi spotifyApi = new SpotifyApi.Builder()
-            .setAccessToken(spotifyConfig.getAccessToken())
-            .build();
+    public SpotifyService(SpotifyConfig spotifyConfig) {
+        this.spotifyConfig = spotifyConfig;
+        this.spotifyApi = new SpotifyApi.Builder()
+                .setAccessToken(spotifyConfig.getAccessToken())
+                .build();
+    }
+
 
     public List<SpotifySearchResponseDto> SearchByTrackname(String trackname) {
 

--- a/src/main/java/com/hositamtam/plypockets/service/SpotifyService.java
+++ b/src/main/java/com/hositamtam/plypockets/service/SpotifyService.java
@@ -7,6 +7,7 @@ import com.hositamtam.plypockets.global.exception.custom.spotify.SpotifyErrorExc
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.hc.core5.http.ParseException;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -25,15 +26,17 @@ import java.util.List;
 @Service
 @Transactional
 @Slf4j
-@RequiredArgsConstructor
+
 public class SpotifyService {
 
-    private final SpotifyConfig spotifyConfig;
+    @Autowired
+    private SpotifyConfig spotifyConfig;
+    private SpotifyApi spotifyApi = new SpotifyApi.Builder()
+            .setAccessToken(spotifyConfig.getAccessToken())
+            .build();
 
     public List<SpotifySearchResponseDto> SearchByTrackname(String trackname) {
-        SpotifyApi spotifyApi = new SpotifyApi.Builder()
-                .setAccessToken(spotifyConfig.getAccessToken())
-                .build();
+
 
         List<SpotifySearchResponseDto> searchResponseDtoList = new ArrayList<>();
 
@@ -73,9 +76,6 @@ public class SpotifyService {
 
 
     public List<SpotifySearchResponseDto> SearchByTracknameAndArtist(String trackname, String Artist) {
-        SpotifyApi spotifyApi = new SpotifyApi.Builder()
-                .setAccessToken(spotifyConfig.getAccessToken())
-                .build();
 
         List<SpotifySearchResponseDto> searchResponseDtoList = new ArrayList<>();
 
@@ -111,9 +111,6 @@ public class SpotifyService {
     }
 
     public List<SpotifySearchResponseDto> searchByGenre(String genre) {
-        SpotifyApi spotifyApi = new SpotifyApi.Builder()
-                .setAccessToken(spotifyConfig.getAccessToken())
-                .build();
 
         List<SpotifySearchResponseDto> searchResponseDtoList = new ArrayList<>();
 
@@ -150,9 +147,6 @@ public class SpotifyService {
 
     @Cacheable(cacheNames = "hot100Cache", key = "'hot100'")
     public List<SpotifySearchResponseDto> getHot100Chart() {
-        SpotifyApi spotifyApi = new SpotifyApi.Builder()
-                .setAccessToken(spotifyConfig.getAccessToken())
-                .build();
 
         List<SpotifySearchResponseDto> searchResponseDtoList = new ArrayList<>();
 
@@ -190,9 +184,7 @@ public class SpotifyService {
 
     @Cacheable(cacheNames = "koreaHot100Cache", key = "'koreaHot100'")
     public List<SpotifySearchResponseDto> getKoreanHot100Chart() {
-        SpotifyApi spotifyApi = new SpotifyApi.Builder()
-                .setAccessToken(spotifyConfig.getAccessToken())
-                .build();
+
 
         List<SpotifySearchResponseDto> searchResponseDtoList = new ArrayList<>();
 
@@ -229,9 +221,6 @@ public class SpotifyService {
     }
 
     public SpotifySearchResponseDto getTrackBySpotifyId(String spotifyId)  {
-        SpotifyApi spotifyApi = new SpotifyApi.Builder()
-                .setAccessToken(spotifyConfig.getAccessToken())
-                .build();
 
         try {
             GetTrackRequest getTrackRequest = spotifyApi.getTrack(spotifyId).build();

--- a/src/main/java/com/hositamtam/plypockets/service/UserService.java
+++ b/src/main/java/com/hositamtam/plypockets/service/UserService.java
@@ -29,40 +29,7 @@ public class UserService {
         this.userRepository = userRepository;
     }
 
-    public User registerUser(UserDto userDto) {
-        User newUser = User.builder()
-                .email(userDto.getEmail())
-                .password(userDto.getPassword())
-                .nickname(userDto.getNickname())
-                .build();
 
-        return userRepository.save(newUser);
-    }
-
-
-    public String getPasswordByEmail(String email) {
-        Optional<User> userOptional = userRepository.findByEmail(email);
-
-        return userOptional.map(User::getPassword).orElse(null);
-    }
-
-    @Getter
-    public static class Response {
-        private Long userId;
-        private String status;
-        private String error;
-
-        public Response(Long userId, String status) {
-            this.userId = userId;
-            this.status = status;
-        }
-
-        public Response(Long userId, String status, String error) {
-            this.userId = userId;
-            this.status = status;
-            this.error = error;
-        }
-    }
     public ResponseEntity<?> loginUser(LoginDto loginRequest) {
         Optional<User> userOptional = userRepository.findByNickname(loginRequest.getNickname());
 


### PR DESCRIPTION
기존의 순수 자바코드로 동작하던 AccessToken을 받는 과정이 담긴SpotifyConfig를 스프링 빈 컨테이너로 등록하여 싱글톤으로 관리되게 하였습니다. 

매번 SpotifyApi의 기능을 사용할때마다 반복 호출 되어서 AccessToken을 받아오는 코드를 스프링 의존주입기능을 활용하여서 속도를 개선하였습니다. 

위 두 과정을 통해 총 API 응답속도를 70.44% 향상시켰습니다.

통제변인 : "hype boy" 노래 검색 

1. 성능개선 전  : 1529 millisecond
![image](https://github.com/Playlist-pack/Server/assets/58305106/02d5fd9d-197a-49f3-afb6-4ddb1afb7ff5)

2. 성능개선 후 : 452 millisecond
![image](https://github.com/Playlist-pack/Server/assets/58305106/2eca8193-4295-4b33-b40f-96acfb6710da)


추가로 `@Value` 애너테이션이 적용되지 않는 문제를 스프링 빈 사이클 주기에 맞추어서 코드를 수정하여서 해결하였고, 토큰을 
감추어서 보안상의 위협을 제거하였습니다.

