### PR TITLE
✔️ [feat] : 토큰 만료확인 후 재발급 기능 구현

### DIFF
--- a/src/main/java/com/hositamtam/plypockets/config/SpotifyConfig.java
+++ b/src/main/java/com/hositamtam/plypockets/config/SpotifyConfig.java
@@ -28,6 +28,11 @@ public class SpotifyConfig {
 
     private static String accessToken;
     private static Instant accessTokenExpiration;
+
+    public static Instant getAccessTokenExpiration() {
+        return accessTokenExpiration;
+    }
+
     @PostConstruct
     public void initialize() {
 
@@ -35,15 +40,6 @@ public class SpotifyConfig {
         refreshAccessToken();
     }
 
-    public String getAccessToken() {
-        if (accessToken == null || Instant.now().isAfter(accessTokenExpiration)) {
-            refreshAccessToken();
-        }
-        return accessToken;
-    }
-    public Instant getAccessTokenExpiration() {
-        return accessTokenExpiration;
-    }
 
     public static SpotifyApi getSpotifyApi() {
         if (spotifyApi == null || Instant.now().isAfter(accessTokenExpiration)) {

--- a/src/main/java/com/hositamtam/plypockets/config/SpotifyConfig.java
+++ b/src/main/java/com/hositamtam/plypockets/config/SpotifyConfig.java
@@ -24,7 +24,7 @@ public class SpotifyConfig {
     @Value("${spotify.registration.client-secret}")
     private String CLIENT_SECRET;
 
-    private SpotifyApi spotifyApi;
+    private static SpotifyApi spotifyApi;
 
     private static String accessToken;
     private static Instant accessTokenExpiration;
@@ -41,8 +41,18 @@ public class SpotifyConfig {
         }
         return accessToken;
     }
+    public Instant getAccessTokenExpiration() {
+        return accessTokenExpiration;
+    }
 
-    private void refreshAccessToken() {
+    public static SpotifyApi getSpotifyApi() {
+        if (spotifyApi == null || Instant.now().isAfter(accessTokenExpiration)) {
+            refreshAccessToken();
+        }
+        return spotifyApi;
+    }
+
+    public static void refreshAccessToken() {
         ClientCredentialsRequest clientCredentialsRequest = spotifyApi.clientCredentials().build();
         try {
             final ClientCredentials clientCredentials = clientCredentialsRequest.execute();

--- a/src/main/java/com/hositamtam/plypockets/service/SpotifyService.java
+++ b/src/main/java/com/hositamtam/plypockets/service/SpotifyService.java
@@ -4,6 +4,7 @@ import com.hositamtam.plypockets.config.SpotifyConfig;
 import com.hositamtam.plypockets.dto.SpotifyDtoMapper;
 import com.hositamtam.plypockets.dto.SpotifySearchResponseDto;
 import com.hositamtam.plypockets.global.exception.custom.spotify.SpotifyErrorException;
+import java.time.Instant;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.hc.core5.http.ParseException;
@@ -34,14 +35,23 @@ public class SpotifyService {
     @Autowired
     public SpotifyService(SpotifyConfig spotifyConfig) {
         this.spotifyConfig = spotifyConfig;
-        this.spotifyApi = new SpotifyApi.Builder()
-                .setAccessToken(spotifyConfig.getAccessToken())
-                .build();
+        this.spotifyApi = spotifyConfig.getSpotifyApi();
     }
+    private void checkAndRefreshToken() {
+        if (spotifyApi.getAccessToken() == null || isTokenExpired()) {
+            spotifyConfig.refreshAccessToken();
+        }
+    }
+
+    private boolean isTokenExpired() {
+        return Instant.now().isAfter(spotifyConfig.getAccessTokenExpiration());
+    }
+
 
 
     public List<SpotifySearchResponseDto> SearchByTrackname(String trackname) {
 
+        checkAndRefreshToken();
 
         List<SpotifySearchResponseDto> searchResponseDtoList = new ArrayList<>();
 
@@ -81,6 +91,7 @@ public class SpotifyService {
 
 
     public List<SpotifySearchResponseDto> SearchByTracknameAndArtist(String trackname, String Artist) {
+        checkAndRefreshToken();
 
         List<SpotifySearchResponseDto> searchResponseDtoList = new ArrayList<>();
 
@@ -116,6 +127,7 @@ public class SpotifyService {
     }
 
     public List<SpotifySearchResponseDto> searchByGenre(String genre) {
+        checkAndRefreshToken();
 
         List<SpotifySearchResponseDto> searchResponseDtoList = new ArrayList<>();
 
@@ -152,6 +164,7 @@ public class SpotifyService {
 
     @Cacheable(cacheNames = "hot100Cache", key = "'hot100'")
     public List<SpotifySearchResponseDto> getHot100Chart() {
+        checkAndRefreshToken();
 
         List<SpotifySearchResponseDto> searchResponseDtoList = new ArrayList<>();
 
@@ -189,6 +202,7 @@ public class SpotifyService {
 
     @Cacheable(cacheNames = "koreaHot100Cache", key = "'koreaHot100'")
     public List<SpotifySearchResponseDto> getKoreanHot100Chart() {
+        checkAndRefreshToken();
 
 
         List<SpotifySearchResponseDto> searchResponseDtoList = new ArrayList<>();
@@ -226,6 +240,7 @@ public class SpotifyService {
     }
 
     public SpotifySearchResponseDto getTrackBySpotifyId(String spotifyId)  {
+        checkAndRefreshToken();
 
         try {
             GetTrackRequest getTrackRequest = spotifyApi.getTrack(spotifyId).build();

--- a/src/main/java/com/hositamtam/plypockets/service/SpotifyService.java
+++ b/src/main/java/com/hositamtam/plypockets/service/SpotifyService.java
@@ -30,7 +30,7 @@ import java.util.List;
 public class SpotifyService {
 
     private final SpotifyConfig spotifyConfig;
-    private final SpotifyApi spotifyApi;
+    private  SpotifyApi spotifyApi;
 
     @Autowired
     public SpotifyService(SpotifyConfig spotifyConfig) {
@@ -40,6 +40,7 @@ public class SpotifyService {
     private void checkAndRefreshToken() {
         if (spotifyApi.getAccessToken() == null || isTokenExpired()) {
             spotifyConfig.refreshAccessToken();
+            this.spotifyApi=spotifyConfig.getSpotifyApi();
         }
     }
 


### PR DESCRIPTION
기존의 코드에서 토큰이 만료되면 spotifyapi가 작동하지 않는 오류를 발견하였고, 해당 부분을 수정하여서, api 호출시마다 토큰을 확인 하고 만약 만료되었다면 재발급 하는 코드로 수정하였습니다. 또한, SpotifyApi를 싱글톤으로 관리하고, getSpotifyApi 메서드를 통해 항상 유효한 SpotifyApi 인스턴스를 반환하도록 수정했습니다. 

1. SpotifyApi 인스턴스를 생성하는 부분을 SpotifyConfig 클래스로 이동하였습니다. SpotifyConfig에서 토큰을 관리하고, SpotifyService에서는 그 토큰을 사용하여 SpotifyApi를 초기화합니다.
2. getHot100Chart 메서드에서 SpotifyApi를 직접 생성하지 않고, spotifyConfig.getSpotifyApi()를 통해 가져오도록 수정하였습니다. 이를 통해 토큰 갱신 등의 관리가 SpotifyConfig에서 이루어지게 되었습니다.
이러한 수정으로 인해 토큰 관리가 중앙에서 이루어지게 되었습니다. 나머지 메서드들도 유사한 방식으로 수정되었습니다.